### PR TITLE
fix setup for openwrt

### DIFF
--- a/setup_on_openwrt.sh
+++ b/setup_on_openwrt.sh
@@ -1,7 +1,7 @@
 
 
 CURRENT_DIR="$( pwd )"
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPT_DIR="$( cd "$( dirname "$[0]" )" && pwd )"
 
 cd $SCRIPT_DIR
 
@@ -12,8 +12,6 @@ if [ ! -d respeaker ]; then
 fi
 
 echo 'Install required python packages'
-pip install -r CherryPy requests
+pip install CherryPy requests
 
 cd $CURRENT_DIR
-
-


### PR DESCRIPTION
Fix 2 errors 

BASH_SOURCE doesn't exist on openwrt

    root@mylinkit:/tmp/run/mountd/mmcblk0p1/alexa# ./setup_on_openwrt.sh
    ./setup_on_openwrt.sh: line 4: syntax error: bad substitution

remove -r from pip install

    root@mylinkit:/tmp/run/mountd/mmcblk0p1/alexa# ./setup_on_openwrt.sh 
    not found respeaker python library, get it from https://github.com/respeaker/respeaker_python_library
    Cloning into 'respeaker_python_library'...
    warning: templates not found /usr/share/git-core/templates
    remote: Counting objects: 56, done.
    remote: Compressing objects: 100% (39/39), done.
    remote: Total 56 (delta 20), reused 52 (delta 16), pack-reused 0
    Unpacking objects: 100% (56/56), done.
    Checking connectivity... done.
    Install required python packages
    Could not open requirements file: [Errno 2] No such file or directory: 'CherryPy'
    Storing debug log for failure in /root/.pip/pip.log
    root@mylinkit:/tmp/run/mountd/mmcblk0p1/alexa#